### PR TITLE
Fix scanpy version requirement to v1.3.2 in .travis (#25)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
       conda config --add channels conda-forge;
       conda config --add channels bioconda;
 
-      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scanpy;
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scanpy=1.3.2;
     fi
 
 install:


### PR DESCRIPTION
* Replace non-ascii left and right single quote with double quotes

* Create .gitattributes

Ignore .travis.yml during `git archive`

* Fix scanpy version requirement to v1.3.2